### PR TITLE
Add plug-in based design blueprint samples

### DIFF
--- a/cloud-assembly/blueprints/PluginBasedDesign/[v1]SimpleAwsInstance/blueprint.yaml
+++ b/cloud-assembly/blueprints/PluginBasedDesign/[v1]SimpleAwsInstance/blueprint.yaml
@@ -1,0 +1,48 @@
+#
+# VMware Cloud Automation Blueprint Sample
+#
+# Copyright 2023 VMware, Inc. All rights reserved
+#
+# The BSD-2 license (the "License") set forth below applies to all parts of the
+# Cloud-automation-samples Code project. You may not use this file except in compliance
+# with the License.
+#
+# BSD-2 License
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+#
+# Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+
+# simple statically configured plug-in based AWS instance
+formatVersion: 1
+inputs: {}
+resources:
+  Idem_AWS_EC2_INSTANCE_1:
+    type: Idem.AWS.EC2.INSTANCE
+    properties:
+      name: my-instance-1
+      region: us-east-1
+      account: AWS
+      image_id: ami-0aa7d40eeae50c9a9
+      availability_zone: us-east-1a
+      instance_type: t2.small
+      subnet_id: subnet-07d2c529b6336bd0e

--- a/cloud-assembly/blueprints/PluginBasedDesign/[v2]InstanceWithComputeAllocation/blueprint.yaml
+++ b/cloud-assembly/blueprints/PluginBasedDesign/[v2]InstanceWithComputeAllocation/blueprint.yaml
@@ -1,0 +1,56 @@
+#
+# VMware Cloud Automation Blueprint Sample
+#
+# Copyright 2023 VMware, Inc. All rights reserved
+#
+# The BSD-2 license (the "License") set forth below applies to all parts of the
+# Cloud-automation-samples Code project. You may not use this file except in compliance
+# with the License.
+#
+# BSD-2 License
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+#
+# Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+
+# plug-in based AWS instance with dynamically configured account, region and
+# availability_zone using a Compute Allocation Helper
+formatVersion: 1
+inputs:
+  instance_name:
+    type: string
+resources:
+  Allocations_Compute_1:
+    type: Allocations.Compute
+    properties:
+      constraints:
+        - tag: env:dev
+  Idem_AWS_EC2_INSTANCE_1:
+    type: Idem.AWS.EC2.INSTANCE
+    properties:
+      name: ${input.instance_name}
+      region: ${resource.Allocations_Compute_1.selectedRegion.id}
+      account: ${resource.Allocations_Compute_1.selectedCloudAccount.name}
+      image_id: ami-0aa7d40eeae50c9a9
+      availability_zone: ${resource.Allocations_Compute_1.selectedPlacementCompute.id}
+      instance_type: t2.small
+      subnet_id: subnet-07d2c529b6336bd0e

--- a/cloud-assembly/blueprints/PluginBasedDesign/[v3]InstanceWithComputeFlavorImageAllocation/blueprint.yaml
+++ b/cloud-assembly/blueprints/PluginBasedDesign/[v3]InstanceWithComputeFlavorImageAllocation/blueprint.yaml
@@ -1,0 +1,65 @@
+#
+# VMware Cloud Automation Blueprint Sample
+#
+# Copyright 2023 VMware, Inc. All rights reserved
+#
+# The BSD-2 license (the "License") set forth below applies to all parts of the
+# Cloud-automation-samples Code project. You may not use this file except in compliance
+# with the License.
+#
+# BSD-2 License
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+#
+# Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+
+# plug-in based AWS instance with dynamically configured account, region,
+# availability_zone, instance_type and image_id using Compute, Flavor and Image
+# Allocation Helpers
+formatVersion: 1
+inputs:
+  instance_name:
+    type: string
+resources:
+  Allocations_Compute_1:
+    type: Allocations.Compute
+    properties:
+      constraints:
+        - tag: env:dev
+  Allocations_Flavor_1:
+    type: Allocations.Flavor
+    properties:
+      flavor: small
+  Allocations_Image_1:
+    type: Allocations.Image
+    properties:
+      image: ubuntu
+  Idem_AWS_EC2_INSTANCE_1:
+    type: Idem.AWS.EC2.INSTANCE
+    properties:
+      name: ${input.instance_name}
+      region: ${resource.Allocations_Compute_1.selectedRegion.id}
+      account: ${resource.Allocations_Compute_1.selectedCloudAccount.name}
+      image_id: ${resource.Allocations_Image_1.selectedImageId}
+      availability_zone: ${resource.Allocations_Compute_1.selectedPlacementCompute.id}
+      instance_type: ${resource.Allocations_Flavor_1.selectedInstanceTypeName}
+      subnet_id: subnet-07d2c529b6336bd0e

--- a/cloud-assembly/blueprints/PluginBasedDesign/[v4]InstanceWithComputeFlavorImageNetworkAllocation/blueprint.yaml
+++ b/cloud-assembly/blueprints/PluginBasedDesign/[v4]InstanceWithComputeFlavorImageNetworkAllocation/blueprint.yaml
@@ -1,0 +1,71 @@
+#
+# VMware Cloud Automation Blueprint Sample
+#
+# Copyright 2023 VMware, Inc. All rights reserved
+#
+# The BSD-2 license (the "License") set forth below applies to all parts of the
+# Cloud-automation-samples Code project. You may not use this file except in compliance
+# with the License.
+#
+# BSD-2 License
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+#
+# Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+
+# plug-in based AWS instance with dynamically configured account, region,
+# availability_zone, instance_type, image_id and subnet_id using Compute,
+# Flavor, Image and Network Allocation Helpers
+formatVersion: 1
+inputs:
+  instance_name:
+    type: string
+resources:
+  Allocations_Compute_1:
+    type: Allocations.Compute
+    properties:
+      constraints:
+        - tag: env:dev
+  Allocations_Flavor_1:
+    type: Allocations.Flavor
+    properties:
+      flavor: small
+  Allocations_Image_1:
+    type: Allocations.Image
+    properties:
+      image: ubuntu
+  Allocations_Network_1:
+    type: Allocations.Network
+    properties:
+      networkType: existing
+      constraints:
+        - tag: alternative-net
+  Idem_AWS_EC2_INSTANCE_1:
+    type: Idem.AWS.EC2.INSTANCE
+    properties:
+      name: ${input.instance_name}
+      region: ${resource.Allocations_Compute_1.selectedRegion.id}
+      account: ${resource.Allocations_Compute_1.selectedCloudAccount.name}
+      image_id: ${resource.Allocations_Image_1.selectedImageId}
+      availability_zone: ${resource.Allocations_Compute_1.selectedPlacementCompute.id}
+      instance_type: ${resource.Allocations_Flavor_1.selectedInstanceTypeName}
+      subnet_id: ${resource.Allocations_Network_1.selectedSubnet.id}

--- a/cloud-assembly/blueprints/PluginBasedDesign/[v5]DynamicallyConfiguredInstancesAndVolume/blueprint.yaml
+++ b/cloud-assembly/blueprints/PluginBasedDesign/[v5]DynamicallyConfiguredInstancesAndVolume/blueprint.yaml
@@ -1,0 +1,98 @@
+#
+# VMware Cloud Automation Blueprint Sample
+#
+# Copyright 2023 VMware, Inc. All rights reserved
+#
+# The BSD-2 license (the "License") set forth below applies to all parts of the
+# Cloud-automation-samples Code project. You may not use this file except in compliance
+# with the License.
+#
+# BSD-2 License
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+#
+# Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+
+# two plug-in based AWS instances and a plug-in based AWS volume, attached to
+# one of the instances, all of which dynamically  configured with the same
+# Allocation Helpers
+formatVersion: 1
+inputs:
+  instance_name:
+    type: string
+  instance2_name:
+    type: string
+  volume_name:
+    type: string
+resources:
+  Allocations_Compute_1:
+    type: Allocations.Compute
+    properties:
+      constraints:
+        - tag: env:dev
+  Allocations_Flavor_1:
+    type: Allocations.Flavor
+    properties:
+      flavor: small
+  Allocations_Image_1:
+    type: Allocations.Image
+    properties:
+      image: ubuntu
+  Allocations_Network_1:
+    type: Allocations.Network
+    properties:
+      networkType: existing
+      constraints:
+        - tag: alternative-net
+  Idem_AWS_EC2_INSTANCE_1:
+    type: Idem.AWS.EC2.INSTANCE
+    properties:
+      name: ${input.instance_name}
+      region: ${resource.Allocations_Compute_1.selectedRegion.id}
+      account: ${resource.Allocations_Compute_1.selectedCloudAccount.name}
+      image_id: ${resource.Allocations_Image_1.selectedImageId}
+      availability_zone: ${resource.Allocations_Compute_1.selectedPlacementCompute.id}
+      instance_type: ${resource.Allocations_Flavor_1.selectedInstanceTypeName}
+      subnet_id: ${resource.Allocations_Network_1.selectedSubnet.id}
+  Idem_AWS_EC2_INSTANCE_2:
+    type: Idem.AWS.EC2.INSTANCE
+    properties:
+      name: ${input.instance2_name}
+      region: ${resource.Allocations_Compute_1.selectedRegion.id}
+      account: ${resource.Allocations_Compute_1.selectedCloudAccount.name}
+      image_id: ${resource.Allocations_Image_1.selectedImageId}
+      availability_zone: ${resource.Allocations_Compute_1.selectedPlacementCompute.id}
+      instance_type: ${resource.Allocations_Flavor_1.selectedInstanceTypeName}
+      subnet_id: ${resource.Allocations_Network_1.selectedSubnet.id}
+      block_device_mappings:
+        - volume_id: ${resource.Idem_AWS_EC2_VOLUME_1.resource_id}
+          device_name: /dev/sdb
+  Idem_AWS_EC2_VOLUME_1:
+    type: Idem.AWS.EC2.VOLUME
+    properties:
+      name: ${input.volume_name}
+      region: ${resource.Allocations_Compute_1.selectedRegion.id}
+      account: ${resource.Allocations_Compute_1.selectedCloudAccount.name}
+      availability_zone: ${resource.Allocations_Compute_1.selectedPlacementCompute.id}
+      size: 10
+      volume_type: io2
+      iops: 100

--- a/cloud-assembly/blueprints/PluginBasedDesign/[v6]DynamicallyConfiguredInstancesVolumeAndKey/blueprint.yaml
+++ b/cloud-assembly/blueprints/PluginBasedDesign/[v6]DynamicallyConfiguredInstancesVolumeAndKey/blueprint.yaml
@@ -1,0 +1,105 @@
+#
+# VMware Cloud Automation Blueprint Sample
+#
+# Copyright 2023 VMware, Inc. All rights reserved
+#
+# The BSD-2 license (the "License") set forth below applies to all parts of the
+# Cloud-automation-samples Code project. You may not use this file except in compliance
+# with the License.
+#
+# BSD-2 License
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+#
+# Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+
+# two plug-in based AWS instances, a plug-in based AWS volume, attached to
+# one of the instances and encrypted with a "classic" KMS key, all of which
+# dynamically configured with the same Allocation Helpers
+formatVersion: 1
+inputs:
+  instance_name:
+    type: string
+  instance2_name:
+    type: string
+  volume_name:
+    type: string
+resources:
+  Allocations_Compute_1:
+    type: Allocations.Compute
+    properties:
+      constraints:
+        - tag: env:dev
+  Allocations_Flavor_1:
+    type: Allocations.Flavor
+    properties:
+      flavor: small
+  Allocations_Image_1:
+    type: Allocations.Image
+    properties:
+      image: ubuntu
+  Allocations_Network_1:
+    type: Allocations.Network
+    properties:
+      networkType: existing
+      constraints:
+        - tag: alternative-net
+  Idem_AWS_EC2_INSTANCE_1:
+    type: Idem.AWS.EC2.INSTANCE
+    properties:
+      name: ${input.instance_name}
+      region: ${resource.Allocations_Compute_1.selectedRegion.id}
+      account: ${resource.Allocations_Compute_1.selectedCloudAccount.name}
+      image_id: ${resource.Allocations_Image_1.selectedImageId}
+      availability_zone: ${resource.Allocations_Compute_1.selectedPlacementCompute.id}
+      instance_type: ${resource.Allocations_Flavor_1.selectedInstanceTypeName}
+      subnet_id: ${resource.Allocations_Network_1.selectedSubnet.id}
+  Idem_AWS_EC2_INSTANCE_2:
+    type: Idem.AWS.EC2.INSTANCE
+    properties:
+      name: ${input.instance2_name}
+      region: ${resource.Allocations_Compute_1.selectedRegion.id}
+      account: ${resource.Allocations_Compute_1.selectedCloudAccount.name}
+      image_id: ${resource.Allocations_Image_1.selectedImageId}
+      availability_zone: ${resource.Allocations_Compute_1.selectedPlacementCompute.id}
+      instance_type: ${resource.Allocations_Flavor_1.selectedInstanceTypeName}
+      subnet_id: ${resource.Allocations_Network_1.selectedSubnet.id}
+      block_device_mappings:
+        - volume_id: ${resource.Idem_AWS_EC2_VOLUME_1.resource_id}
+          device_name: /dev/sdb
+  Idem_AWS_EC2_VOLUME_1:
+    type: Idem.AWS.EC2.VOLUME
+    properties:
+      name: ${input.volume_name}
+      region: ${resource.Allocations_Compute_1.selectedRegion.id}
+      account: ${resource.Allocations_Compute_1.selectedCloudAccount.name}
+      availability_zone: ${resource.Allocations_Compute_1.selectedPlacementCompute.id}
+      size: 10
+      volume_type: io2
+      iops: 100
+      encrypted: true
+      kms_key_id: ${resource.Cloud_Service_AWS_KMS_Key_1.key_id}
+  Cloud_Service_AWS_KMS_Key_1:
+    type: Cloud.Service.AWS.KMS.Key
+    properties:
+      region: ${resource.Allocations_Compute_1.selectedRegion.id}
+      account: ${resource.Allocations_Compute_1.selectedCloudAccount.name}

--- a/cloud-assembly/blueprints/README.md
+++ b/cloud-assembly/blueprints/README.md
@@ -14,8 +14,23 @@ The blueprint.yaml must have the following
     
 We have the following sample blueprints:
 
-*  DockerHost:      Blueprint to deploy a docker host
-*  TestRunner:      Blueprint to test Tito Application using Cypress and use Locus for load testing
-*  Tito:            Blueprint to deploy Tito Application
-*  TitoRoute53:     Blueprint to deploy Tito Application using AWS Route53 as Load Balancer
-*  WavefrontProxy:  Blueprint to deploy wavefront proxy
+* DockerHost:      Blueprint to deploy a docker host
+* TestRunner:      Blueprint to test Tito Application using Cypress and use Locus for load testing
+* Tito:            Blueprint to deploy Tito Application
+* TitoRoute53:     Blueprint to deploy Tito Application using AWS Route53 as Load Balancer
+* WavefrontProxy:  Blueprint to deploy wavefront proxy
+* PluginBasedDesign:
+    * [v1]SimpleAwsInstance: Blueprint to deploy simple statically configured plug-in based AWS instance
+    * [v2]InstanceWithComputeAllocation: Blueprint to deploy plug-in based AWS instance with dynamically configured
+account, region and availability_zone using a Compute Allocation Helper
+    * [v3]InstanceWithComputeFlavorImageAllocation: Blueprint to deploy plug-in based AWS instance with dynamically
+configured account, region, availability_zone, instance_type and image_id using Compute, Flavor and Image Allocation
+Helpers
+    * [v4]InstanceWithComputeFlavorImageNetworkAllocation: Blueprint to deploy plug-in based AWS instance with
+dynamically configured account, region, availability_zone, instance_type, image_id and subnet_id using Compute, Flavor,
+Image and Network Allocation Helpers
+    * [v5]DynamicallyConfiguredInstancesAndVolume: Blueprint to deploy two plug-in based AWS instances and a plug-in
+based AWS volume, attached to one of the instances, all of which dynamically configured with the same Allocation Helpers
+    * [v6]DynamicallyConfiguredInstancesVolumeAndKey: Blueprint to deploy two plug-in based AWS instances, a plug-in
+based AWS volume, attached to one of the instances and encrypted with a "classic" KMS key, all of which dynamically
+configured with the same Allocation Helpers


### PR DESCRIPTION
Aria Automation introduces new plug-in based designs and deployments model in 8.12.0 (April) release. We have a tutorial to help users get started with the new
capabilities. The tutorial includes 6 versions of a plug-in based design blueprint.

Add all versions of the blueprint with descriptions to the cloud assembly blueprint samples to allow users to easily take them, tweak them for their use cases and evolve them however they need.